### PR TITLE
Update compulsory fields (name and phone) for create command.

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateCommandParser.java
@@ -41,18 +41,18 @@ public class CreateCommandParser implements Parser<CreateCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_DESCRIPTION, PREFIX_NETWORTH, PREFIX_MEETING_TIME, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_NETWORTH, PREFIX_MEETING_TIME, PREFIX_EMAIL)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateCommand.MESSAGE_USAGE));
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        Description description = new Description(argMultimap.getValue(PREFIX_DESCRIPTION).get().trim());
-        NetWorth netWorth = ParserUtil.parseNetWorth(argMultimap.getValue(PREFIX_NETWORTH).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).orElse(""));
+        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).orElse(""));
+        Description description =
+                ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).orElse(""));
+        NetWorth netWorth = ParserUtil.parseNetWorth(argMultimap.getValue(PREFIX_NETWORTH).orElse(""));
         Set<MeetingTime> meetingTimeList = ParserUtil.parseMeetingTimes(argMultimap.getAllValues(PREFIX_MEETING_TIME));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         FilePath filePath = new FilePath(""); // add command does not allow adding file path straight away

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,6 +10,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Description;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FilePath;
 import seedu.address.model.person.MeetingTime;
@@ -71,15 +72,10 @@ public class ParserUtil {
     /**
      * Parses a {@code String address} into an {@code Address}.
      * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given {@code address} is invalid.
      */
-    public static Address parseAddress(String address) throws ParseException {
+    public static Address parseAddress(String address) {
         requireNonNull(address);
         String trimmedAddress = address.trim();
-        if (!Address.isValidAddress(trimmedAddress)) {
-            throw new ParseException(Address.MESSAGE_CONSTRAINTS);
-        }
         return new Address(trimmedAddress);
     }
 
@@ -99,6 +95,16 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String description} into an {@code Description}.
+     * Leading and trailing whitespaces will be trimmed.
+     */
+    public static Description parseDescription(String description) {
+        requireNonNull(description);
+        String trimmedDescription = description.trim();
+        return new Description(trimmedDescription);
+    }
+
+    /**
      * Parses a {@code String tag} into a {@code Tag}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -107,7 +113,6 @@ public class ParserUtil {
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
         String trimmedTag = tag.trim().toUpperCase();
-        System.out.println("trimmed tag: " + trimmedTag);
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -1,21 +1,12 @@
 package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Person's address in the address book.
- * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
+ * Guarantees: immutable; is always valid
  */
 public class Address {
-
-    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
-
-    /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String value;
 
@@ -26,15 +17,7 @@ public class Address {
      */
     public Address(String address) {
         requireNonNull(address);
-        checkArgument(isValidAddress(address), MESSAGE_CONSTRAINTS);
         value = address;
-    }
-
-    /**
-     * Returns true if a given string is a valid address.
-     */
-    public static boolean isValidAddress(String test) {
-        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -9,6 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Email {
 
+    private static final String EMPTY_EMAIL = "";
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
@@ -48,7 +49,7 @@ public class Email {
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.equals(EMPTY_EMAIL) || test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NetWorth.java
+++ b/src/main/java/seedu/address/model/person/NetWorth.java
@@ -9,6 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class NetWorth {
 
+    public static final String EMPTY_NETWORTH = "";
     public static final String MESSAGE_CONSTRAINTS =
             "Net worth should only contain numbers and net worth should be at least 4 digits";
     public static final String VALIDATION_REGEX = "[$][1-9]\\d{3,}";
@@ -29,7 +30,7 @@ public class NetWorth {
      * Returns true if a given string is a valid networth.
      */
     public static boolean isValidNetWorth(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.equals("") || test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -126,9 +126,7 @@ class JsonAdaptedPerson {
         if (address == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
         }
-        if (!Address.isValidAddress(address)) {
-            throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
-        }
+
         final Address modelAddress = new Address(address);
 
         if (netWorth == null) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -46,7 +46,11 @@ public class CommandTestUtil {
     public static final String VALID_MEETING_TIME_BOB = "18-12-2022-13:30";
     public static final String VALID_FILEPATH_AMY = "src/test/data/TestPDFs/Test_PDF.pdf";
     public static final String VALID_FILEPATH_BOB = "src/test/data/TestPDFs/Test_PDF2.pdf";
+    public static final String EMPTY_ADDRESS = "";
+    public static final String EMPTY_DESCRIPTION = "";
+    public static final String EMPTY_EMAIL = "";
     public static final String EMPTY_FILEPATH = "";
+    public static final String EMPTY_NETWORTH = "";
     public static final String VALID_TAG_POTENTIAL = "POTENTIAL";
     public static final String VALID_TAG_SECURED = "SECURED";
 
@@ -72,7 +76,6 @@ public class CommandTestUtil {
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
-    public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_NETWORTH_DESC = " " + PREFIX_NETWORTH + "1222"; // missing '$' symbol
     public static final String INVALID_FILEPATH_DESC = " " + PREFIX_FILEPATH + "misc/Test_PDF2"; // missing '.pdf' label
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby"; // not SECURED or POTENTIAL

--- a/src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java
@@ -7,9 +7,11 @@ import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMPTY_ADDRESS;
+import static seedu.address.logic.commands.CommandTestUtil.EMPTY_DESCRIPTION;
+import static seedu.address.logic.commands.CommandTestUtil.EMPTY_EMAIL;
 import static seedu.address.logic.commands.CommandTestUtil.EMPTY_FILEPATH;
-import static seedu.address.logic.commands.CommandTestUtil.FILEPATH_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.EMPTY_NETWORTH;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_MEETING_TIME;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
@@ -43,7 +45,6 @@ import static seedu.address.testutil.TypicalPersons.BOB;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.CreateCommand;
-import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.MeetingTime;
 import seedu.address.model.person.Name;
@@ -105,10 +106,48 @@ public class CreateCommandParserTest {
 
     @Test
     public void parse_optionalFieldsMissing_success() {
-        // zero tags and no remark
+
+        // missing address prefix
+        Person noAddressPerson = new PersonBuilder(AMY).withAddress(EMPTY_ADDRESS).buildNoFilePath();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
+                        + DESCRIPTION_DESC_AMY + NETWORTH_DESC_AMY + MEETING_TIME_DESC_AMY + TAG_DESC_SECURED,
+                new CreateCommand(noAddressPerson));
+
+        // missing email prefix
+        Person noEmailPerson = new PersonBuilder(AMY).withEmail(EMPTY_EMAIL).buildNoFilePath();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY
+                + DESCRIPTION_DESC_AMY + NETWORTH_DESC_AMY + MEETING_TIME_DESC_AMY + TAG_DESC_SECURED,
+                new CreateCommand(noEmailPerson));
+
+        // missing description prefix
+        Person noDescriptionPerson = new PersonBuilder(AMY).withDescription(EMPTY_DESCRIPTION).buildNoFilePath();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                        + NETWORTH_DESC_AMY + MEETING_TIME_DESC_AMY + TAG_DESC_SECURED,
+                new CreateCommand(noDescriptionPerson));
+
+        // missing networth prefix
+        Person noNetworthPerson = new PersonBuilder(AMY).withNetWorth(EMPTY_NETWORTH).buildNoFilePath();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                        + DESCRIPTION_DESC_AMY + MEETING_TIME_DESC_AMY + TAG_DESC_SECURED,
+                new CreateCommand(noNetworthPerson));
+
+        // missing meeting time prefix
+        Person noMeetingTimePerson = new PersonBuilder(AMY).withMeetingTimes().buildNoFilePath();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                        + DESCRIPTION_DESC_AMY + NETWORTH_DESC_AMY + TAG_DESC_SECURED,
+                new CreateCommand(noMeetingTimePerson));
+
+        // zero tags and no filepath
         Person expectedPerson = new PersonBuilder(AMY).withTags().buildNoFilePath();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
                 + NETWORTH_DESC_AMY + MEETING_TIME_DESC_AMY + DESCRIPTION_DESC_AMY, new CreateCommand(expectedPerson));
+
+        // missing every optional field
+        Person noNothingPerson = new PersonBuilder(AMY).withEmail(EMPTY_EMAIL).withDescription(EMPTY_DESCRIPTION)
+                .withMeetingTimes().withTags().withAddress(EMPTY_ADDRESS).withNetWorth(EMPTY_NETWORTH)
+                .buildNoFilePath();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY, new CreateCommand(noNothingPerson));
+
     }
 
     @Test
@@ -121,14 +160,6 @@ public class CreateCommandParserTest {
 
         // missing phone prefix
         assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
                 expectedMessage);
 
         // all prefixes missing
@@ -153,11 +184,6 @@ public class CreateCommandParserTest {
                 + DESCRIPTION_DESC_BOB + NETWORTH_DESC_BOB + MEETING_TIME_DESC_BOB + TAG_DESC_POTENTIAL,
                 Email.MESSAGE_CONSTRAINTS);
 
-        // invalid address
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + DESCRIPTION_DESC_BOB + NETWORTH_DESC_BOB + MEETING_TIME_DESC_BOB + FILEPATH_DESC_BOB
-                + TAG_DESC_POTENTIAL, Address.MESSAGE_CONSTRAINTS);
-
         // invalid networth
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + DESCRIPTION_DESC_BOB + INVALID_NETWORTH_DESC + MEETING_TIME_DESC_BOB + TAG_DESC_POTENTIAL
@@ -174,7 +200,7 @@ public class CreateCommandParserTest {
                 Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
                 + DESCRIPTION_DESC_BOB + NETWORTH_DESC_BOB + MEETING_TIME_DESC_BOB , Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -22,7 +22,6 @@ import seedu.address.model.tag.Tag;
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
-    private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_FILEPATH = "misc/Test_PDF.p";
     private static final String INVALID_TAG = "#friend";
@@ -106,11 +105,6 @@ public class ParserUtilTest {
     @Test
     public void parseAddress_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseAddress(null));
-    }
-
-    @Test
-    public void parseAddress_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseAddress(INVALID_ADDRESS));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UpdateCommandParserTest.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NETWORTH_DESC;
@@ -40,7 +39,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UpdateCommand;
 import seedu.address.logic.commands.UpdateCommand.EditPersonDescriptor;
-import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.NetWorth;
@@ -89,7 +87,6 @@ public class UpdateCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
         assertParseFailure(parser, "1" + INVALID_NETWORTH_DESC, NetWorth.MESSAGE_CONSTRAINTS); //invalid networth
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 

--- a/src/test/java/seedu/address/model/person/AddressTest.java
+++ b/src/test/java/seedu/address/model/person/AddressTest.java
@@ -1,7 +1,5 @@
 package seedu.address.model.person;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -13,24 +11,4 @@ public class AddressTest {
         assertThrows(NullPointerException.class, () -> new Address(null));
     }
 
-    @Test
-    public void constructor_invalidAddress_throwsIllegalArgumentException() {
-        String invalidAddress = "";
-        assertThrows(IllegalArgumentException.class, () -> new Address(invalidAddress));
-    }
-
-    @Test
-    public void isValidAddress() {
-        // null address
-        assertThrows(NullPointerException.class, () -> Address.isValidAddress(null));
-
-        // invalid addresses
-        assertFalse(Address.isValidAddress("")); // empty string
-        assertFalse(Address.isValidAddress(" ")); // spaces only
-
-        // valid addresses
-        assertTrue(Address.isValidAddress("Blk 456, Den Road, #01-355"));
-        assertTrue(Address.isValidAddress("-")); // one character
-        assertTrue(Address.isValidAddress("Leng Inc; 1234 Market St; San Francisco CA 2349879; USA")); // long address
-    }
 }

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -15,7 +15,7 @@ public class EmailTest {
 
     @Test
     public void constructor_invalidEmail_throwsIllegalArgumentException() {
-        String invalidEmail = "";
+        String invalidEmail = "invalid#this";
         assertThrows(IllegalArgumentException.class, () -> new Email(invalidEmail));
     }
 
@@ -24,8 +24,10 @@ public class EmailTest {
         // null email
         assertThrows(NullPointerException.class, () -> Email.isValidEmail(null));
 
-        // blank email
-        assertFalse(Email.isValidEmail("")); // empty string
+        // empty email
+        assertTrue(Email.isValidEmail("")); // empty string
+
+        // blank email (note the difference between "" and " ")
         assertFalse(Email.isValidEmail(" ")); // spaces only
 
         // missing parts

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -23,7 +23,6 @@ import seedu.address.model.person.Phone;
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
-    private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_NETWORTH = "€12";
     private static final String INVALID_FILEPATH = "src/main/resources/misc/Test_PDF.wowzers";
@@ -104,16 +103,6 @@ public class JsonAdaptedPersonTest {
                 VALID_DESCRIPTION, VALID_NETWORTH, VALID_MEETING_TIMES, VALID_FILEPATH, VALID_TAGS);
 
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
-    }
-
-    @Test
-    public void toModelType_invalidAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                        VALID_DESCRIPTION, VALID_NETWORTH, VALID_MEETING_TIMES, VALID_FILEPATH, VALID_TAGS);
-
-        String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -16,6 +16,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NETWORTH_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_POTENTIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SECURED;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -73,7 +74,7 @@ public class TypicalPersons {
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withNetWorth(VALID_NETWORTH_AMY)
             .withDescription(VALID_DESCRIPTION_AMY).withMeetingTimes(VALID_MEETING_TIME_AMY)
-            .withFilePath(EMPTY_FILEPATH).withTags(VALID_TAG_POTENTIAL).build();
+            .withFilePath(EMPTY_FILEPATH).withTags(VALID_TAG_SECURED).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withNetWorth(VALID_NETWORTH_BOB)
             .withDescription(VALID_DESCRIPTION_BOB).withMeetingTimes(VALID_MEETING_TIME_BOB)


### PR DESCRIPTION
bugs/defects that weren't fixed in this PR:

As peter mentioned, moving/renaming the file on disk causes FABook to abort save file. possible fix: stop checking validness of filepath at launch.

Filepath is still not allowed at contact creation. Testing with filepaths is limited.

