### PR TITLE
[Shaune] Make empty fields not visible in person profile Closes #97

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CreateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateCommand.java
@@ -35,7 +35,7 @@ public class CreateCommand extends UndoableCommand {
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_NETWORTH + "$1423 "
-            + PREFIX_MEETING_TIME + "15-12-2022-19:00"
+            + PREFIX_MEETING_TIME + "15-12-2022-19:00 "
             + PREFIX_TAG + "Potential";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -53,6 +53,13 @@ public class Address {
         return value == EMPTY_ADDRESS ? PersonProfile.EMPTY_DISPLAY_VALUE : value;
     }
 
+    /**
+     * Returns true if value is empty.
+     */
+    public boolean isEmpty() {
+        return value.equals(EMPTY_ADDRESS);
+    }
+
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/address/model/person/Description.java
+++ b/src/main/java/seedu/address/model/person/Description.java
@@ -36,6 +36,13 @@ public class Description {
         return value == EMPTY_DESCRIPTION ? PersonProfile.EMPTY_DISPLAY_VALUE : value;
     }
 
+    /**
+     * Returns true if value is empty.
+     */
+    public boolean isEmpty() {
+        return value.equals(EMPTY_DESCRIPTION);
+    }
+
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -68,6 +68,13 @@ public class Email {
         return value == EMPTY_EMAIL ? PersonProfile.EMPTY_DISPLAY_VALUE : value;
     }
 
+    /**
+     * Returns true if value is empty.
+     */
+    public boolean isEmpty() {
+        return value.equals(EMPTY_EMAIL);
+    }
+
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/address/model/person/FilePath.java
+++ b/src/main/java/seedu/address/model/person/FilePath.java
@@ -39,6 +39,9 @@ public class FilePath {
         this.value = filePath;
     }
 
+    /**
+     * Returns true if value is empty.
+     */
     public boolean isEmpty() {
         return value.isEmpty();
     }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -57,6 +57,13 @@ public class Name {
         return fullName == EMPTY_NAME ? PersonProfile.EMPTY_DISPLAY_VALUE : fullName;
     }
 
+    /**
+     * Returns true if fullName is empty.
+     */
+    public boolean isEmpty() {
+        return fullName.equals(EMPTY_NAME);
+    }
+
     @Override
     public String toString() {
         return fullName;

--- a/src/main/java/seedu/address/model/person/NetWorth.java
+++ b/src/main/java/seedu/address/model/person/NetWorth.java
@@ -48,6 +48,13 @@ public class NetWorth {
         return test.equals(EMPTY_NETWORTH) || test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns true if value is empty.
+     */
+    public boolean isEmpty() {
+        return value.equals(EMPTY_NETWORTH);
+    }
+
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -49,6 +49,13 @@ public class Phone {
         return value == EMPTY_PHONE ? PersonProfile.EMPTY_DISPLAY_VALUE : value;
     }
 
+    /**
+     * Returns true if value is empty.
+     */
+    public boolean isEmpty() {
+        return value.equals(EMPTY_PHONE);
+    }
+
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/address/ui/PersonProfile.java
+++ b/src/main/java/seedu/address/ui/PersonProfile.java
@@ -86,6 +86,9 @@ public class PersonProfile extends UiPart<Region> {
         setPersonFileButton();
     }
 
+    /**
+     * Sets name value in name if value is not empty.
+     */
     private void setNameField() {
         if (person.getName().isEmpty()) {
             name.setManaged(false);
@@ -95,6 +98,9 @@ public class PersonProfile extends UiPart<Region> {
         name.setText(person.getName().getFullDisplayName());
     }
 
+    /**
+     * Sets phone value in phone if value is not empty.
+     */
     private void setPhoneField() {
         if (person.getPhone().isEmpty()) {
             phone.setManaged(false);
@@ -104,6 +110,9 @@ public class PersonProfile extends UiPart<Region> {
         phone.setText(person.getPhone().getDisplayValue());
     }
 
+    /**
+     * Sets address value in address if value is not empty.
+     */
     private void setAddressField() {
         if (person.getAddress().isEmpty()) {
             address.setManaged(false);
@@ -113,6 +122,9 @@ public class PersonProfile extends UiPart<Region> {
         address.setText(person.getAddress().getDisplayValue());
     }
 
+    /**
+     * Sets email value in email if value is not empty.
+     */
     private void setEmailField() {
         if (person.getEmail().isEmpty()) {
             email.setManaged(false);
@@ -122,6 +134,9 @@ public class PersonProfile extends UiPart<Region> {
         email.setText(person.getEmail().getDisplayValue());
     }
 
+    /**
+     * Sets description value in description if value is not empty.
+     */
     private void setDescriptionField() {
         if (person.getDescription().isEmpty()) {
             description.setManaged(false);
@@ -131,6 +146,9 @@ public class PersonProfile extends UiPart<Region> {
         description.setText(person.getDescription().getDisplayValue());
     }
 
+    /**
+     * Sets netWorth value in netWorth if value is not empty.
+     */
     private void setNetWorthField() {
         if (person.getNetWorth().isEmpty()) {
             netWorth.setManaged(false);
@@ -140,6 +158,9 @@ public class PersonProfile extends UiPart<Region> {
         netWorth.setText(person.getNetWorth().getDisplayValue());
     }
 
+    /**
+     * Sets person meetingTimes in meetingTimes if meetingTimes is not empty.
+     */
     private void setMeetingsField() {
         if (person.getMeetingTimes().isEmpty()) {
             meetingTimes.setManaged(false);
@@ -150,6 +171,9 @@ public class PersonProfile extends UiPart<Region> {
                 .forEach(meetingTime -> meetingTimes.getChildren().add(new Label(meetingTime.displayValue)));
     }
 
+    /**
+     * Sets person tags in tags if tags is not empty.
+     */
     private void setTagsField() {
         if (person.getTags().isEmpty()) {
             tags.setManaged(false);
@@ -160,6 +184,9 @@ public class PersonProfile extends UiPart<Region> {
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }
 
+    /**
+     * Sets personFileButton to unmanaged if filepath is empty.
+     */
     private void setPersonFileButton() {
         if (person.getFilePath().isEmpty()) {
             personFileButton.setManaged(false);

--- a/src/main/java/seedu/address/ui/PersonProfile.java
+++ b/src/main/java/seedu/address/ui/PersonProfile.java
@@ -57,11 +57,15 @@ public class PersonProfile extends UiPart<Region> {
     @FXML
     private Label description_label;
     @FXML
+    private Label tags_label;
+    @FXML
     private FlowPane tags;
     @FXML
     private Label netWorth;
     @FXML
     private Label netWorth_label;
+    @FXML
+    private Label meeting_label;
     @FXML
     private FlowPane meetingTimes;
     @FXML
@@ -164,6 +168,7 @@ public class PersonProfile extends UiPart<Region> {
     private void setMeetingsField() {
         if (person.getMeetingTimes().isEmpty()) {
             meetingTimes.setManaged(false);
+            meeting_label.setManaged(false);
             return;
         }
         person.getMeetingTimes().stream()
@@ -177,6 +182,7 @@ public class PersonProfile extends UiPart<Region> {
     private void setTagsField() {
         if (person.getTags().isEmpty()) {
             tags.setManaged(false);
+            tags_label.setManaged(false);
             return;
         }
         person.getTags().stream()

--- a/src/main/java/seedu/address/ui/PersonProfile.java
+++ b/src/main/java/seedu/address/ui/PersonProfile.java
@@ -83,6 +83,7 @@ public class PersonProfile extends UiPart<Region> {
         setNetWorthField();
         setMeetingsField();
         setTagsField();
+        setPersonFileButton();
     }
 
     private void setNameField() {
@@ -140,15 +141,30 @@ public class PersonProfile extends UiPart<Region> {
     }
 
     private void setMeetingsField() {
+        if (person.getMeetingTimes().isEmpty()) {
+            meetingTimes.setManaged(false);
+            return;
+        }
         person.getMeetingTimes().stream()
                 .sorted(Comparator.comparing(meetingTime -> meetingTime.displayValue))
                 .forEach(meetingTime -> meetingTimes.getChildren().add(new Label(meetingTime.displayValue)));
     }
 
     private void setTagsField() {
+        if (person.getTags().isEmpty()) {
+            tags.setManaged(false);
+            return;
+        }
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+
+    private void setPersonFileButton() {
+        if (person.getFilePath().isEmpty()) {
+            personFileButton.setManaged(false);
+            return;
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/ui/PersonProfile.java
+++ b/src/main/java/seedu/address/ui/PersonProfile.java
@@ -39,17 +39,29 @@ public class PersonProfile extends UiPart<Region> {
     @FXML
     private Label name;
     @FXML
+    private Label name_label;
+    @FXML
     private Label phone;
+    @FXML
+    private Label phone_label;
     @FXML
     private Label address;
     @FXML
+    private Label address_label;
+    @FXML
     private Label email;
     @FXML
+    private Label email_label;
+    @FXML
     private Label description;
+    @FXML
+    private Label description_label;
     @FXML
     private FlowPane tags;
     @FXML
     private Label netWorth;
+    @FXML
+    private Label netWorth_label;
     @FXML
     private FlowPane meetingTimes;
     @FXML
@@ -63,15 +75,77 @@ public class PersonProfile extends UiPart<Region> {
     public PersonProfile(Person person) {
         super(FXML);
         this.person = person;
+        setNameField();
+        setPhoneField();
+        setAddressField();
+        setEmailField();
+        setDescriptionField();
+        setNetWorthField();
+        setMeetingsField();
+        setTagsField();
+    }
+
+    private void setNameField() {
+        if (person.getName().isEmpty()) {
+            name.setManaged(false);
+            name_label.setManaged(false);
+            return;
+        }
         name.setText(person.getName().getFullDisplayName());
+    }
+
+    private void setPhoneField() {
+        if (person.getPhone().isEmpty()) {
+            phone.setManaged(false);
+            phone_label.setManaged(false);
+            return;
+        }
         phone.setText(person.getPhone().getDisplayValue());
+    }
+
+    private void setAddressField() {
+        if (person.getAddress().isEmpty()) {
+            address.setManaged(false);
+            address_label.setManaged(false);
+            return;
+        }
         address.setText(person.getAddress().getDisplayValue());
+    }
+
+    private void setEmailField() {
+        if (person.getEmail().isEmpty()) {
+            email.setManaged(false);
+            email_label.setManaged(false);
+            return;
+        }
         email.setText(person.getEmail().getDisplayValue());
+    }
+
+    private void setDescriptionField() {
+        if (person.getDescription().isEmpty()) {
+            description.setManaged(false);
+            description_label.setManaged(false);
+            return;
+        }
         description.setText(person.getDescription().getDisplayValue());
+    }
+
+    private void setNetWorthField() {
+        if (person.getNetWorth().isEmpty()) {
+            netWorth.setManaged(false);
+            netWorth_label.setManaged(false);
+            return;
+        }
         netWorth.setText(person.getNetWorth().getDisplayValue());
+    }
+
+    private void setMeetingsField() {
         person.getMeetingTimes().stream()
                 .sorted(Comparator.comparing(meetingTime -> meetingTime.displayValue))
                 .forEach(meetingTime -> meetingTimes.getChildren().add(new Label(meetingTime.displayValue)));
+    }
+
+    private void setTagsField() {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -143,14 +143,14 @@
     -fx-font-family: "Segoe UI";
     -fx-font-size: 16px;
     -fx-text-fill: white;
-    -fx-padding: 10 0 0 0;
+    -fx-padding: 0 0 0 0;
 }
 
 .display_content{
     -fx-font-family: "Segoe UI";
     -fx-font-size: 20px;
     -fx-text-fill: #a1c3da;
-    -fx-padding: 0 0 5 0;
+    -fx-padding: 0 0 20 0;
 }
 
 .stack-pane {
@@ -237,7 +237,8 @@
     -fx-padding: 5 22 5 22;
     -fx-border-color: #e2e2e2;
     -fx-border-width: 2;
-    -fx-background-radius: 0;
+    -fx-border-radius: 4;
+    -fx-background-radius: 4;
     -fx-background-color: #1d1d1d;
     -fx-font-family: "Segoe UI", Helvetica, Arial, sans-serif;
     -fx-font-size: 11pt;
@@ -372,6 +373,16 @@
     -fx-font-size: 11;
 }
 
+#mainDisplay #tags .label {
+    -fx-text-fill: white;
+    -fx-background-color: #3e7b91;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 16;
+    -fx-padding: 0 10 0 10;
+}
+
 #meetingTimes {
     -fx-hgap: 7;
     -fx-vgap: 3;
@@ -386,34 +397,26 @@
     -fx-font-size: 11;
 }
 
-#mainDisplay #tags {
-    -fx-hgap: 10;
-    -fx-vgap: 6;
-    -fx-padding: 5 0 5 0;
-}
-
-#mainDisplay #tags .label {
-    -fx-text-fill: white;
-    -fx-background-color: #3e7b91;
-    -fx-padding: 1 3 1 3;
-    -fx-border-radius: 2;
-    -fx-background-radius: 2;
-    -fx-font-size: 15;
-}
-
-#mainDisplay #meetingTimes {
-    -fx-hgap: 10;
-    -fx-vgap: 6;
-    -fx-padding: 5 0 5 0;
-}
-
 #mainDisplay #meetingTimes .label {
     -fx-text-fill: white;
     -fx-background-color: #21cc3d;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
     -fx-background-radius: 2;
-    -fx-font-size: 15;
+    -fx-font-size: 16;
+    -fx-padding: 0 10 0 10;
+}
+
+#mainDisplay #tags {
+    -fx-hgap: 10;
+    -fx-vgap: 6;
+    -fx-padding: 5 0 20 0;
+}
+
+#mainDisplay #meetingTimes {
+    -fx-hgap: 10;
+    -fx-vgap: 6;
+    -fx-padding: 5 0 20 0;
 }
 
 #mainDisplay #buttonErrorMessage {

--- a/src/main/resources/view/PersonProfile.fxml
+++ b/src/main/resources/view/PersonProfile.fxml
@@ -22,15 +22,15 @@
             </HBox>
             <FlowPane fx:id="tags" />
             <FlowPane fx:id="meetingTimes" />
-            <Label styleClass="display_label" text="Phone Number" />
+            <Label fx:id="phone_label" styleClass="display_label" text="Phone Number" />
             <Label fx:id="phone" styleClass="display_content" text="\$phone" />
-            <Label styleClass="display_label" text="Address" />
+            <Label fx:id="address_label" styleClass="display_label" text="Address" />
             <Label fx:id="address" styleClass="display_content" text="\$address" />
-            <Label styleClass="display_label" text="Email" />
+            <Label fx:id="email_label" styleClass="display_label" text="Email" />
             <Label fx:id="email" styleClass="display_content" text="\$email" />
-            <Label styleClass="display_label" text="Description" />
+            <Label fx:id="description_label" styleClass="display_label" text="Description" />
             <Label fx:id="description" styleClass="display_content" text="\$description" />
-            <Label styleClass="display_label" text="Net Worth" />
+            <Label fx:id="netWorth_label" styleClass="display_label" text="Net Worth" />
             <Label fx:id="netWorth" styleClass="display_content" text="\$netWorth" />
             <Button fx:id="personFileButton" styleClass="display_button" onMouseClicked="#openPersonFile" text="Client Information" />
             <Label fx:id="buttonErrorMessage" styleClass="error_message" managed="false" />

--- a/src/main/resources/view/PersonProfile.fxml
+++ b/src/main/resources/view/PersonProfile.fxml
@@ -20,7 +20,9 @@
             <HBox alignment="CENTER_LEFT" spacing="5">
                 <Label fx:id="name" styleClass="display_header" text="\$first" />
             </HBox>
+            <Label fx:id="tags_label" styleClass="display_label" text="Status" />
             <FlowPane fx:id="tags" />
+            <Label fx:id="meeting_label" styleClass="display_label" text="Meeting Times" />
             <FlowPane fx:id="meetingTimes" />
             <Label fx:id="phone_label" styleClass="display_label" text="Phone Number" />
             <Label fx:id="phone" styleClass="display_content" text="\$phone" />


### PR DESCRIPTION
## Completed:
* Made empty fields not visible in person profile
## How:
1. Checks for empty field when loading person profile
2. If field is empty, set the display label and content label of that field to not managed